### PR TITLE
Icub oculus fixes

### DIFF
--- a/icub/conf/gazebo_icub_head.ini
+++ b/icub/conf/gazebo_icub_head.ini
@@ -28,9 +28,9 @@ name head
 # this information is used to set the PID values in simulation for GAZEBO, we need only the first three values
 [GAZEBO_PIDS]
 #head
-Pid0 50.0 7.0 0.1 9999 9999 9 9
-Pid1 50.0 7.0 0.1 9999 9999 9 9
-Pid2 50.0 7.0 0.1 9999 9999 9 9
+Pid0 100.0 7.0 0.2 9999 9999 9 9
+Pid1 100.0 7.0 0.2 9999 9999 9 9
+Pid2 100.0 7.0 0.2 9999 9999 9 9
 
 [GAZEBO_VELOCITY_PIDS]
 #head

--- a/icub/icub.sdf
+++ b/icub/icub.sdf
@@ -1446,8 +1446,8 @@
       <axis>
         <xyz>-4.69281e-06 1 6.74621e-11</xyz>
         <limit>
-          <lower>-0.698132</lower>
-          <upper>0.523599</upper>
+          <lower>-0.523599</lower>
+          <upper>0.383972</upper>
           <effort>20</effort>
           <velocity>100</velocity>
         </limit>
@@ -1499,8 +1499,8 @@
       <axis>
         <xyz>-1 -4.69282e-06 1.46928e-05</xyz>
         <limit>
-          <lower>-1.22173</lower>
-          <upper>1.0472</upper>
+          <lower>-0.349066</lower>
+          <upper>0.349066</upper>
           <effort>20</effort>
           <velocity>100</velocity>
         </limit>
@@ -1562,8 +1562,8 @@
       <axis>
         <xyz>1.46928e-05 1.48834e-12 1</xyz>
         <limit>
-          <lower>-0.959931</lower>
-          <upper>0.959931</upper>
+          <lower>-0.767945</lower>
+          <upper>0.767945</upper>
           <effort>20</effort>
           <velocity>100</velocity>
         </limit>


### PR DESCRIPTION
A couple of fixes to the icub model in order to use it with the oculus:

 * Increase head PIDs
 * Change head joints limit to match with the real iCub
  * Pitch: [-30,22]
  * Roll: [-20,20]
  * Yaw: [-44,44]